### PR TITLE
updated fluentd image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,37 @@
-FROM alpine:3.4
+FROM alpine:latest
 
-# Do not split this into multiple RUN!
-# Docker creates a layer for every RUN-Statement
-# therefore an 'apk delete build*' has no effect
-RUN apk --no-cache add \
-                   build-base \
-                   libffi-dev \
-                   ca-certificates \
-                   ruby \
-                   ruby-irb \
-                   ruby-dev && \
-    echo 'gem: --no-document' >> /etc/gemrc && \
-    gem install oj && \
-    gem install json && \
-    gem install fluentd -v 0.12.31 && \
-    gem install fluent-plugin-kubernetes_metadata_filter && \
-    gem install fluent-plugin-syslog-tls && \
-    apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+RUN apk update \
+ && apk upgrade \
+ && apk add --no-cache \
+        ca-certificates \
+        ruby ruby-irb \
+ && apk add --no-cache --virtual .build-deps \
+        build-base \
+        libffi-dev \
+        ruby-dev wget gnupg \
+ && update-ca-certificates \
+ && echo 'gem: --no-document' >> /etc/gemrc \
+ && gem install oj -v 2.18.3 \
+ && gem install json -v 2.1.0 \
+ && gem install fluentd -v 0.14.23 \
+ && gem install fluent-plugin-kubernetes_metadata_filter \
+ && gem install fluent-plugin-syslog-tls \
+ && apk del build-base ruby-dev libffi-dev \
+ && apk del .build-deps \
+ && rm -rf /var/cache/apk/* \
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
 RUN chown -R fluent:fluent /home/fluent
-
 # for log storage (maybe shared with host)
 RUN mkdir -p /fluentd/log
 # configuration/plugins path (default: copied from .)
 RUN mkdir -p /fluentd/etc /fluentd/plugins
-
 RUN chown -R fluent:fluent /fluentd
 
 # !!!!! This runs as root to access external k8s volumes !!!!!
 USER root
 WORKDIR /home/fluent
-
-# Tell ruby to install packages as user
-RUN echo "gem: --user-install --no-document" >> ~/.gemrc
-ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
-ENV GEM_PATH /home/fluent/.gem/ruby/2.3.0:$GEM_PATH
 
 COPY fluent.conf /fluentd/etc/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+
+all:
+	docker build . -t quay.io/mozmar/fluentd:${GIT_COMMIT}
+	docker push quay.io/mozmar/fluentd:${GIT_COMMIT}


### PR DESCRIPTION
- fluentd gem updated to 0.14.23, which is the [latest](https://rubygems.org/gems/fluentd)
- based on https://github.com/fluent/fluentd-docker-image/blob/master/v0.14/alpine/Dockerfile with tweaks to make it work with syslog/K8s
- makefile generates a hashed tag instead of `:latest`
- tested in my namespace on Frankfurt, I was able to send logs to the [oregon-b](https://papertrailapp.com/groups/6778452) log destination.